### PR TITLE
Fix the app.gradle to enable multidex

### DIFF
--- a/app/App_Resources/Android/app.gradle
+++ b/app/App_Resources/Android/app.gradle
@@ -9,6 +9,7 @@ android {
   defaultConfig {  
     generatedDensities = []
     applicationId = "org.nativescript.selfieMania" 
+    multiDexEnabled true
     
     //override supported platforms
     // ndk {


### PR DESCRIPTION
The app and the libraries it references exceeds some numer of methods, that encounter a build error that indicates your app has reached the limit of the Android build architecture. I was facing this issue therefore adding this fix to it.